### PR TITLE
Remove condition on pull_request events

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,14 +17,6 @@ if [[ -f "build.gradle" ]]; then
   exit 1
 fi
 
-if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-  EVENT_ACTION=$(jq -r ".action" "${GITHUB_EVENT_PATH}")
-  if [[ "${EVENT_ACTION}" != "opened" ]]; then
-	  echo "No need to run analysis. It is already triggered by the push event."
-	  exit 78
-  fi
-fi
-
 if [[ -z "${SONARCLOUD_URL}" ]]; then
   SONARCLOUD_URL="https://sonarcloud.io"
 fi


### PR DESCRIPTION
Introduces a way to run the scanner action on `pull_request`
events by setting the `SCAN_PULL_REQUEST` environment flag.