### PR TITLE
Add support of project base dir from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Using this GitHub Action, scan your code with [SonarCloud](https://sonarcloud.io
 
 <img src="./images/SonarCloud-72px.png">
 
-SonarCloud is the leading product for Continuous Code Quality & Code Security online, totally free for open-source projects. It supports all major programming languages, including Java, JavaScript, TypeScript, C#, C/C++ and many more. If your code is closed source, SonarCloud also offers a paid plan to run private analyses
+SonarCloud is the leading product for Continuous Code Quality & Code Security online, totally free for open-source projects. It supports all major programming languages, including Java, JavaScript, TypeScript, C#, C/C++ and many more. If your code is closed source, SonarCloud also offers a paid plan to run private analyses.
 
 ## Requirements
 
@@ -22,6 +22,14 @@ sonar.projectKey=<replace with the key generated when setting up the project on 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/ 
 sonar.sources=.
+```
+
+You can change the analysis base directory by using the optional input `projectBaseDir` like this:
+
+```yaml
+uses: sonarsource/sonarcloud-github-action@master
+with:
+  projectBaseDir: my-custom-directory
 ```
 
 The workflow, usually declared in `.github/workflows/build.yml`, looks like:

--- a/action.yml
+++ b/action.yml
@@ -6,3 +6,8 @@ branding:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  projectBaseDir:
+    description: 'Set the sonar.projectBaseDir analysis property'
+    required: false
+    default: '.'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,6 @@ if [[ -z "${SONARCLOUD_URL}" ]]; then
   SONARCLOUD_URL="https://sonarcloud.io"
 fi
 
-sonar-scanner -Dsonar.host.url=${SONARCLOUD_URL}
+sonar-scanner -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} -Dsonar.host.url=${SONARCLOUD_URL}
 
 


### PR DESCRIPTION
This change allows to use the environment variable SONAR_PROJECT_BASE_DIR to set the sonar.projectBaseDir property.

This is useful for monorepos, where you may want to use different settings for different sub-projets.

The change does nothing if the variable is not set.
