### PR TITLE
Git Fetch Depth Configuration Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 ```
+In order to provide features such blame information, it is necessary not to use a shallow copy of the git. To make this possible, change the above configuration for the checkout: 
+```
+uses: actions/checkout@v2
+with:
+  fetch-depth: 0
+```
+More detailed description [here](https://github.com/actions/checkout).
 
 You can change the analysis base directory by using the optional input `projectBaseDir` like this:
 


### PR DESCRIPTION
I propose to add a description of the checkout configuration necessary to increase the depth of the git clone. This is needed for features like blame information. 

The configuration/solution was originally described by Tom Van Braband in this thread https://community.sonarsource.com/t/sonarcloud-with-github-actions/22713.

 I really think this should be part of the documentation.