### PR TITLE
Set up locale env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ ARG NODEJS_HOME=/opt/nodejs
 
 ENV PATH=${PATH}:${SONAR_SCANNER_HOME}/bin:${NODEJS_HOME}/bin
 
+# set up local envs in order to allow for special chars (non-asci) in filenames
+ENV LC_ALL="C.UTF-8"
+
 WORKDIR /opt
 
 # https://help.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user


### PR DESCRIPTION
Setting those variables fixes the issue that sonar has with non-asci chars in filenames