### PR TITLE
Fix Set SONAR_TOKEN env variable error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${SONAR_TOKEN}" ]]; then
+if [[ -z "${secrets.SONAR_TOKEN}" ]]; then
   echo "Set the SONAR_TOKEN env variable."
   exit 1
 fi


### PR DESCRIPTION
Fix Set SONAR_TOKEN env variable error. It should be based on ${secrets.SONAR_TOKEN}

<img width="926" alt="Screen Shot 2021-02-20 at 10 49 43 pm" src="https://user-images.githubusercontent.com/548371/108594419-00def100-73ce-11eb-9e02-f9c08a1d0e5c.png">
