### PR TITLE
Bugfix/set sonar token error2

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${secrets.SONAR_TOKEN}" ]]; then
+if [[ -z "${env.SONAR_TOKEN}" ]]; then
   echo "Set the SONAR_TOKEN env variable."
   exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${SONAR_TOKEN}" ]]; then
+if [[ -z "${secrets.SONAR_TOKEN}" ]]; then
   echo "Set the SONAR_TOKEN env variable."
   exit 1
 fi


### PR DESCRIPTION
Fix Set SONAR_TOKEN env variable error.
Another alternative PR, It should be based on ${env.SONAR_TOKEN}

<img width="926" alt="Screen Shot 2021-02-20 at 10 49 43 pm" src="https://user-images.githubusercontent.com/548371/108594535-ab571400-73ce-11eb-9eb8-a0983414a5a2.png">
