### PR TITLE
Bugfix/remove set sonar token

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${secrets.SONAR_TOKEN}" ]]; then
+if [[ -z "${env.SONAR_TOKEN}" ]]; then
   echo "Set the SONAR_TOKEN env variable."
   exit 1
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [[ -z "${env.SONAR_TOKEN}" ]]; then
-  echo "Set the SONAR_TOKEN env variable."
-  exit 1
-fi
-
 if [[ -f "pom.xml" ]]; then
   echo "Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
   exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ -z "${SONAR_TOKEN}" ]]; then
+if [[ -z "${secrets.SONAR_TOKEN}" ]]; then
   echo "Set the SONAR_TOKEN env variable."
   exit 1
 fi


### PR DESCRIPTION
I am using Github Actions to configure sonar cloud

Following is snippet of the code
steps:
- uses: actions/checkout@v2
- name: Use Node.js {{ matrix.node-version }} uses: actions/setup-node@v1 with: node-version: {{ matrix.node-version }}
- name: SonarCloud Scan
uses: sonarsource/sonarcloud-github-action@master
env:
GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }} SONAR_TOKEN: {{ secrets.SONAR_TOKEN }}

Following is the sonar-project.propertiest
sonar.organization=“react-hook-form”
sonar.projectKey=“react-hook-form_error-message”
sonar.sources="./src"

The Sonar Cloud analyse successful but your entry point checking for SONAR TOKEN which should be secrets.SONAR_TOKEN.