### PR TITLE
Build-Push Docker image to ghcr.io

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,24 @@
+name: Build and publish to ghcr.io
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  IMAGE_NAME: sonarcloud-github-action
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag ghcr.io/$GITHUB_ACTOR/$IMAGE_NAME:`basename $GITHUB_REF` --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push docker image
+        run:  docker push ghcr.io/$GITHUB_ACTOR/$IMAGE_NAME:`basename $GITHUB_REF`

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -3,7 +3,9 @@ name: Build and publish to ghcr.io
 on:
   push:
     branches: [ master ]
-
+  release:
+    types: [published]
+    
 env:
   IMAGE_NAME: sonarcloud-github-action
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
     - name: SonarCloud Scan
-      uses: sonarsource/sonarcloud-github-action@master
+      uses: docker://ghcr.io/sonarsource/sonarcloud-github-action:v1.9
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
 You can change the analysis base directory by using the optional input `projectBaseDir` like this:
 
 ```yaml
-uses: sonarsource/sonarcloud-github-action@master
+uses: docker://ghcr.io/sonarsource/sonarcloud-github-action:v1.9
 with:
   projectBaseDir: my-custom-directory
 ```
@@ -64,7 +64,7 @@ In case you need to add additional analysis parameters, you can use the `args` o
 
 ```yaml
 - name: Analyze with SonarCloud
-  uses: sonarsource/sonarcloud-github-action@master
+  uses: docker://ghcr.io/sonarsource/sonarcloud-github-action:v1.9
   with:
     projectBaseDir: my-custom-directory
     args: >


### PR DESCRIPTION
When running this github actions with `uses: sonarsource/sonarcloud-github-action@master`, there is a build time of around 17 seconds everytime the action is run.

To shorten this build time I was using a fork, and a build on Docker Hub, to directly pull using `uses: docker://toindev/sonarcloud-github-action:latest` shaving around 10 seconds on every build (this adds up on a Github org with a number of projects).

Now that Github Actions supports using docker images hosted on the Github Docker Registry, I think it would be nice to have the official actions already built, and be able to `uses: docker://ghcr.io/SonarSource/sonarcloud-github-action:latest`. It seems to shave 2 or 3 extra seconds as well.

I have purposefully avoided using external actions (beside Github's) to avoid dependencies, and only build on the master branch.

**NOTE**: For this to work, the "Improved Container Support" must be activated for the SonarSource Organization.