### PR TITLE
Remove token requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ https://sonarcloud.io/documentation/analysis/analysis-parameters/
 
 ### Secrets
 
-- `SONAR_TOKEN` – **Required** this is the token used to authenticate access to SonarCloud. You can generate a token on your [Security page in SonarCloud](https://sonarcloud.io/account/security/). You can set the `SONAR_TOKEN` environment variable in the "Secrets" settings page of your repository.
+- `SONAR_TOKEN` – This is the token used to authenticate access to SonarCloud. You can generate a token on your [Security page in SonarCloud](https://sonarcloud.io/account/security/). You can set the `SONAR_TOKEN` environment variable in the "Secrets" settings page of your repository.
 - *`GITHUB_TOKEN` – Provided by Github (see [Authenticating with the GITHUB_TOKEN](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token)).*
 
 ## Example of pull request analysis

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [[ -z "${SONAR_TOKEN}" ]]; then
-  echo "Set the SONAR_TOKEN env variable."
-  exit 1
-fi
-
 if [[ -f "pom.xml" ]]; then
   echo "Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
   exit 1


### PR DESCRIPTION
Since SonarQube has the option to allow scan to run without authentication token, this change removes the hard requirement from the token from the action.