### PR TITLE
Only warn if pom.xml is found

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,7 @@ if [[ -z "${SONAR_TOKEN}" ]]; then
 fi
 
 if [[ -f "pom.xml" ]]; then
-  echo "Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
-  exit 1
+  echo "WARN: Maven project detected. You should run the goal 'org.sonarsource.scanner.maven:sonar' during build rather than using this GitHub Action."
 fi
 
 if [[ -f "build.gradle" ]]; then


### PR DESCRIPTION
See: https://community.sonarsource.com/t/maven-project-detected-you-should-run-the-goal-org-sonarsource-scanner-maven-sonar-during-build-rather-than-using-this-github-action/36158