### PR TITLE
fix: allow non-ascii chars in filenames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ ENV PATH=${PATH}:${SONAR_SCANNER_HOME}/bin:${NODEJS_HOME}/bin
 
 # set up local envs in order to allow for special chars (non-asci) in filenames
 ENV LC_ALL="C.UTF-8"
+ENV LANG="C.UTF-8"
 
 WORKDIR /opt
 


### PR DESCRIPTION
Based on https://github.com/SonarSource/sonarcloud-github-action/pull/22
Taking suggestion from https://github.com/SonarSource/sonarcloud-github-action/pull/22#issuecomment-983037682