### PR TITLE
Enable debug logging when GitHub Actions debug logging is enabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,5 +20,11 @@ fi
 if [[ -z "${SONARCLOUD_URL}" ]]; then
   SONARCLOUD_URL="https://sonarcloud.io"
 fi
+
+debug_flag=''
+if [[ "$RUNNER_DEBUG" == '1' ]]; then
+  debug_flag=' --debug '
+fi
+
 unset JAVA_HOME
-sonar-scanner -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} -Dsonar.host.url=${SONARCLOUD_URL} ${INPUT_ARGS}
+sonar-scanner $debug_flag -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} -Dsonar.host.url=${SONARCLOUD_URL} ${INPUT_ARGS}


### PR DESCRIPTION
When a user enables debug logging for a workflow (i.e. when re-running a job), this action will now check to see whether that flag has been enabled and thus enable debug logging in the sonar scanner as well.

Documentation: https://docs.github.com/en/actions/learn-github-actions/variables

<img width="761" alt="image" src="https://user-images.githubusercontent.com/1388505/216836470-d4082f0f-70f3-4a17-8e97-fab2a8c6b5e0.png">
