### PR TITLE
Update sonar-scanner-cli to v5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarsource/sonar-scanner-cli:4.8
+FROM sonarsource/sonar-scanner-cli:5.0
 
 LABEL version="0.0.1" \
       repository="https://github.com/sonarsource/sonarcloud-github-action" \


### PR DESCRIPTION
Addresses the deprecation warning:
> The version of Java (11.0.20) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.

Ref cli commit: https://github.com/SonarSource/sonar-scanner-cli/commit/4ed7c3568a584d84a667248f59ac6d99f6954309
Ref docs: https://docs.sonarcloud.io/appendices/scanner-environment/