### PR TITLE
Update cleanup.sh: Added input validation for projectBaseDir

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ -z "${INPUT_PROJECTBASEDIR}" ]]; then
+  echo "Error: It seems like you forgot to define the input variable with name PROJECTBASEDIR."
+  exit 1
+fi
+
 _tmp_file=$(ls "${INPUT_PROJECTBASEDIR}/" | head -1)
 PERM=$(stat -c "%u:%g" "${INPUT_PROJECTBASEDIR}/$_tmp_file")
 


### PR DESCRIPTION
Added input validation for PROJECTBASEDIR

If you don't set the input projectBaseDir it's causing an error like this:

Error: Access to the path '/home/runner/work/_temp/_github_workflow/event.json' is denied.