### PR TITLE
Update entrypoint.sh to correctly detect gradle

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ if [[ -f "${INPUT_PROJECTBASEDIR%/}/pom.xml" ]]; then
   exit 1
 fi
 
-if [[ -f "${INPUT_PROJECTBASEDIR%/}/build.gradle" ]]; then
+if [[ -f "${INPUT_PROJECTBASEDIR%/}/build.gradle" ]] || [[ -f "${INPUT_PROJECTBASEDIR%/}/build.gradle.kts" ]] || [[ -f "${INPUT_PROJECTBASEDIR%/}/settings.gradle" ]] || [[ -f "${INPUT_PROJECTBASEDIR%/}/settings.gradle.kts" ]]; then
   echo "Gradle project detected. You should use the SonarQube plugin for Gradle during build rather than using this GitHub Action."
   exit 1
 fi


### PR DESCRIPTION
The current version of the `entrypoint.sh` covers only the scenario when `build.gradle` is present in the root of the project which can lead to a GHA being executed for projects that have `build.gradle.kts` instead of `build.gradle` or some projects with submodules that might not have the `build.gradle` in their root.

For projects that have submodules, `settings.gradle` or `settings.gradle.kts` is mandatory to be in the root so this PR ensures all scenarios are covered.