### PR TITLE
Fix dockerfile building error after upgrade of base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarsource/sonar-scanner-cli:5.0
+FROM sonarsource/sonar-scanner-cli:5.0.0
 
 LABEL version="0.0.1" \
       repository="https://github.com/sonarsource/sonarcloud-github-action" \


### PR DESCRIPTION
Latest release of https://hub.docker.com/r/sonarsource/sonar-scanner-cli breaks this action as in:

![image](https://github.com/SonarSource/sonarcloud-github-action/assets/570991/25e1205b-61c9-461f-ba4a-a0b985a496c7)

Version history of docker image:

![image](https://github.com/SonarSource/sonarcloud-github-action/assets/570991/0bbb13d4-7870-4365-bc40-57814ef445d5)


The proposed solution is to keep the GH Action building from the last known good docker image, upgrades to the base docker image should be tested in a branch and then promoted to the main branch (master in this repo)