### PR TITLE
Use Docker's built-in `COPY --chmod` functionality to fix the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ ENV LC_ALL="C.UTF-8"
 WORKDIR /opt
 
 # Prepare entrypoint
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-COPY cleanup.sh /cleanup.sh
-RUN chmod +x /cleanup.sh
+COPY --chmod=775 entrypoint.sh /entrypoint.sh
+COPY --chmod=775 cleanup.sh /cleanup.sh
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
This fixes an issue we were seeing when building the action:

      chmod: /entrypoint.sh: Operation not permitted

While maintaining the required end effect (presumably only necessary when building the image on Windows).

See also #67 for a solution that pins down the version (but doesn't permanently fix this particular bug).