### PR TITLE
bug-fix: update-dockerfile/USER root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,11 @@ ENV LC_ALL="C.UTF-8"
 
 WORKDIR /opt
 
+USER root
+
 # Prepare entrypoint
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 COPY cleanup.sh /cleanup.sh
 RUN chmod +x /cleanup.sh
 ENTRYPOINT ["/entrypoint.sh"]
-


### PR DESCRIPTION
The recent `sonar-scanner-cli` image (v5.0) changes the user which causes the `docker build` failure

![image](https://github.com/SonarSource/sonarcloud-github-action/assets/19498202/250b4595-fde2-4443-b087-1b1df9415a6a)
![image](https://github.com/SonarSource/sonarcloud-github-action/assets/19498202/c70ca063-959d-4b6f-908a-3b1ecad5b16b)


Running the commands as `root` resolve the issue.

[bug-fix: k1ch/update-dockerfile/USER root](https://github.com/SonarSource/sonarcloud-github-action/commit/50b914169b51aba98c43f7022bfe879b6d620952)

![image](https://github.com/SonarSource/sonarcloud-github-action/assets/19498202/e4f2f1b6-fac0-4f45-9819-0ae8b20bc951)

