### PR TITLE
Changed base image from dockerhub to ECR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM sonarsource/sonar-scanner-cli:10.0
+FROM public.ecr.aws/l3k7d6g6/sonarsource/sonar-scanner-cli:10.0
 
 LABEL version="2.2.0" \
-      repository="https://github.com/sonarsource/sonarcloud-github-action" \
-      homepage="https://github.com/sonarsource/sonarcloud-github-action" \
-      maintainer="SonarSource" \
+      repository="https://github.com/bucketplace/sonarcloud-github-action" \
+      homepage="https://github.com/bucketplace/sonarcloud-github-action" \
+      maintainer="Eng/Core" \
       com.github.actions.name="SonarCloud Scan" \
-      com.github.actions.description="Scan your code with SonarCloud to detect bugs, vulnerabilities and code smells in more than 25 programming languages." \
+      com.github.actions.description="This repository is forked from SonarSource/sonarcloud-github-action to avoid DockerHub throttle limit." \
       com.github.actions.icon="check" \
       com.github.actions.color="green"
 


### PR DESCRIPTION
Forked GitHub action to use image from ECR Public to avoid DockerHub throttle limit. 

ECR Public repo is created in ohouse-mgmt account. 
https://gallery.ecr.aws/l3k7d6g6/sonarsource/sonar-scanner-cli