### PR TITLE
Prevent globbing and word splitting

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -10,5 +10,5 @@ fi
 _tmp_file=$(ls "${INPUT_PROJECTBASEDIR}/" | head -1)
 PERM=$(stat -c "%u:%g" "${INPUT_PROJECTBASEDIR}/$_tmp_file")
 
-chown -R $PERM "${INPUT_PROJECTBASEDIR}/.scannerwork/"
+chown -R "$PERM" "${INPUT_PROJECTBASEDIR}/.scannerwork/"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,4 +27,4 @@ if [[ "$RUNNER_DEBUG" == '1' ]]; then
 fi
 
 unset JAVA_HOME
-sonar-scanner $debug_flag -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} -Dsonar.host.url=${SONARCLOUD_URL} ${INPUT_ARGS}
+sonar-scanner "$debug_flag" -Dsonar.projectBaseDir="${INPUT_PROJECTBASEDIR}" -Dsonar.host.url="${SONARCLOUD_URL}" "${INPUT_ARGS}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,4 +27,4 @@ if [[ "$RUNNER_DEBUG" == '1' ]]; then
 fi
 
 unset JAVA_HOME
-sonar-scanner "$debug_flag" -Dsonar.projectBaseDir="${INPUT_PROJECTBASEDIR}" -Dsonar.host.url="${SONARCLOUD_URL}" "${INPUT_ARGS}"
+sonar-scanner $debug_flag -Dsonar.projectBaseDir=${INPUT_PROJECTBASEDIR} -Dsonar.host.url=${SONARCLOUD_URL} ${INPUT_ARGS}


### PR DESCRIPTION
Not using double quotes here might cause _globbing and word splitting_ (cf. [SC2086](https://www.shellcheck.net/wiki/SC2086)).

Similar to SonarSource/sonarcloud-github-c-cpp#60.