### PR TITLE
BUILD-6088 Fix bad link in SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Reporting Security Issues
+
+A mature software vulnerability treatment process is a cornerstone of a robust information security management system. Contributions from the community play an important role in the evolution and security of our products, and in safeguarding the security and privacy of our users.
+
+If you believe you have discovered a security vulnerability in Sonar's products, we encourage you to report it immediately.
+
+To responsibly report a security issue, please email us at [security@sonarsource.com](mailto:security@sonarsource.com). Sonar’s security team will acknowledge your report, guide you through the next steps, or request additional information if necessary. Customers with a support contract can also report the vulnerability directly through the support channel.
+
+For security vulnerabilities found in third-party libraries, please also contact the library's owner or maintainer directly.
+
+## Responsible Disclosure Policy
+
+For more information about disclosing a security vulnerability to Sonar, please refer to our community post: [Responsible Vulnerability Disclosure](https://community.sonarsource.com/t/responsible-vulnerability-disclosure/9317).


### PR DESCRIPTION
This file needs to be present for all Sonar public repositories, for more information please refer to BUILD-6088.