### PR TITLE
Update reusable action version to latest available

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
       run: |
         echo "::warning title=SonarScanner::This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action."
     - name: SonarQube Cloud Scan
-      uses: SonarSource/sonarqube-scan-action@v4.1.0
+      uses: SonarSource/sonarqube-scan-action@v5.0.0
       with:
         args: ${{ inputs.args }}
         projectBaseDir: ${{ inputs.projectBaseDir }}


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

Update version to use latest SonarSource/sonarqube-scan-action

currently getting this error on our runners due to a depreciated cache version action that has been resolved in the reusable action but not updated yet on the reusable workflow

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/ab2b0473-e620-421f-9079-eae06e9c2b6e" />


the PR that fixed the change on the reusable action side https://github.com/SonarSource/sonarqube-scan-action/pull/161
