### PR TITLE
BUILD-8073 Migrate public repositories workflows to large runners

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestClosed_job:
     name: Pull Request Closed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -54,7 +54,7 @@ jobs:
   scannerVersionTest:
     name: >
       'scannerVersion' input
-    runs-on: ubuntu-latest # assumes default RUNNER_ARCH for linux is X64
+    runs-on: ubuntu-latest-large # assumes default RUNNER_ARCH for linux is X64
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,7 +74,7 @@ jobs:
   scannerBinariesUrlTest:
     name: >
       'scannerBinariesUrl' input with invalid URL
-    runs-on: ubuntu-latest # assumes default RUNNER_ARCH for linux is X64
+    runs-on: ubuntu-latest-large # assumes default RUNNER_ARCH for linux is X64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-large
     permissions:
       contents: write
 


### PR DESCRIPTION
[BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073)

Migrates public repository workflows from standard GitHub-hosted runners to **Large Runners**
(`ubuntu-latest` → `ubuntu-latest-large`, etc.).

See [BUILD-8073](https://sonarsource.atlassian.net/browse/BUILD-8073) for details.


[BUILD-8073]: https://sonarsource.atlassian.net/browse/BUILD-8073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ