### PR TITLE
Use commit SHA pinning for action metadata files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
       run: |
         echo "::warning title=SonarScanner::This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action."
     - name: SonarQube Cloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5.0.0
+      uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d # v5.0.0
       with:
         args: ${{ inputs.args }}
         projectBaseDir: ${{ inputs.projectBaseDir }}


### PR DESCRIPTION
I’d like to propose updating this action to use SHA pinning, similar to https://github.com/SonarSource/sonarqube-scan-action/pull/202.

I understand that this action is deprecated; however, it is still used quite extensively on our end. With that in mind, I thought it might be useful to update this action as well to follow the SHA pinning best practice, if you find it appropriate.